### PR TITLE
Add matcher

### DIFF
--- a/Caddyfile.sublime-syntax
+++ b/Caddyfile.sublime-syntax
@@ -72,6 +72,7 @@ contexts:
       set: server_block
 
   server_block:
+    - include: matcher
     - match: "{{directive}}"
       captures:
         1: support.function.Caddyfile
@@ -92,3 +93,6 @@ contexts:
     - match: '"'
       pop: true
 
+  matcher:
+    - match: "(?<!\\w)@\\w+"
+      scope: entity.name.matcher.Caddyfile


### PR DESCRIPTION
Caddyfile is so well designed. The syntax definition hasn't really needed much update since 1.0.0. Thank you very much for that!

Just adding matcher to highlight it a little bit.

Before:

![image](https://user-images.githubusercontent.com/1329716/221074059-d371b6d5-bb06-45bf-9471-c956334218cc.png)

After:

![image](https://user-images.githubusercontent.com/1329716/221074106-5fab1f8a-21d2-4c68-b96c-530c0b47b1bc.png)
